### PR TITLE
Adding Regex to GloballyUniqueCompanyIdentifier

### DIFF
--- a/pipeline-template.yml
+++ b/pipeline-template.yml
@@ -5,6 +5,8 @@ Parameters:
   GloballyUniqueCompanyIdentifier:
     Type: String
     Description: Used to prefix S3 Bucket names (that must be globally unique) to ensure there will be no conflict
+    AllowedPattern: "(?!(^xn--))^[a-z0-9][a-z0-9-]{0,19}$"
+    ConstraintDescription: "Malformed input-parameter GloballyUniqueCompanyIdentifier must only contains lowercase letter, numbers and hyphens (-) ; and is limited to 20 characters"
   ProjectName:
     Type: String
     Description: Name of the project to insert in all the resource names


### PR DESCRIPTION
Adding regex to GloballyUniqueCompanyIdentifier as it must respect S3 constraints (nothing else than hyphen and lowercase letter, numbers and must not start with xn--) to avoid user to put jibberish and having stack failing after 5 min because of an upper letter